### PR TITLE
docker fix for linux repository cuda key rotation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM tensorflow/tensorflow:2.3.1-gpu
 # FROM tensorflow/tensorflow:2.4.0rc0-gpu
 MAINTAINER moono.song "toilety@gmail.com"
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN apt-key del 7fa2af80
 RUN apt-get update -y
 RUN apt-get install -y build-essential
 RUN pip install pillow


### PR DESCRIPTION
NVIDIA updated their [CUDA Linux GPG Repository Key](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/), the dockerfile creation now crashes.
Workaround from [here](https://forums.developer.nvidia.com/t/18-04-cuda-docker-image-is-broken/212892).